### PR TITLE
feat: use switch-case to match subcommands

### DIFF
--- a/cmd/sysl/cmd_mod.go
+++ b/cmd/sysl/cmd_mod.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/anz-bank/sysl/pkg/mod"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -12,23 +11,27 @@ type modCmd struct {
 	modName string
 }
 
+var (
+	initCmd *kingpin.CmdClause
+)
+
 func (m *modCmd) Name() string       { return "mod" }
 func (m *modCmd) MaxSyslModule() int { return 0 }
 
 func (m *modCmd) Configure(app *kingpin.Application) *kingpin.CmdClause {
-	cmd := app.Command(m.Name(), "Configure sysl module system")
-	initCmd := cmd.Command("init", "sysl module init command")
-	initCmd.Arg("mod name", "Name of sysl module").Required().StringVar(&m.modName)
+	cmd := app.Command(m.Name(), "provides access to operations on Sysl modules")
+	initCmd = cmd.Command("init", "initializes and writes a new go.mod to the current directory")
+	initCmd.Arg("name", "path of current sysl module").StringVar(&m.modName)
 
 	return cmd
 }
 
 func (m *modCmd) Execute(args ExecuteArgs) error {
 	// subcommands are somewhat funky using the cmd_runner
-	subcommand := strings.Split(args.Command, " ")[1]
-	if subcommand == "init" {
+	switch args.Command {
+	case initCmd.FullCommand():
 		return mod.SyslModInit(m.modName, args.Logger)
+	default:
+		return errors.New("command not recognized")
 	}
-
-	return errors.New("command not recognized")
 }

--- a/pkg/mod/mod_init.go
+++ b/pkg/mod/mod_init.go
@@ -1,8 +1,9 @@
 package mod
 
 import (
+	"context"
 	"fmt"
-	"os/exec"
+	"io/ioutil"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -13,11 +14,10 @@ import (
 // we hijack this command and use go.mod and possibly go.sum to determine
 // whether the current folder/project is a sysl module
 func SyslModInit(modName string, logger *logrus.Logger) error {
-	out, err := exec.Command("go", "mod", "init", modName).CombinedOutput()
+	err := runGo(context.Background(), ioutil.Discard, "mod", "init", modName)
 	if err != nil {
 		return errors.New(fmt.Sprintf("go mod init failed: %s", err.Error()))
 	}
 
-	logger.Info(string(out))
 	return nil
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- use switch-case to match subcommands

@anz-bank/sysl-developers
